### PR TITLE
Fix module load error

### DIFF
--- a/pytradier/company/stats.py
+++ b/pytradier/company/stats.py
@@ -1,5 +1,5 @@
-from pytradier import base
-from pytradier.const import API_ENDPOINT, API_PATH
+from .. import base
+from ..const import API_ENDPOINT, API_PATH
 
 class Stats:
 


### PR DESCRIPTION
As it currently stands, importing pytradier may result in ModuleNotFoundError: No module named 'pytradier'.